### PR TITLE
Update Node runtime to v24.8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.19.0
+          node-version: 24.8.0
           cache: yarn
           cache-dependency-path: |
             yarn.lock

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.19.0
+          node-version: 24.8.0
           cache: yarn
           cache-dependency-path: |
             yarn.lock

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@
 
 - 秘密情報はコミットしない（Sentry DSN/GA は公開前提。他のトークンは環境変数管理）。
 - `VITE_LAST_MODIFIED` はフッター表示に使用（`Makefile` が自動設定）。
-- Node は Docker と同等（v20.19 系）か互換環境を推奨。
+- Node は Docker と同等（v24.8 系）か互換環境を推奨。
 
 ## Agent 向け補足
 
@@ -53,7 +53,7 @@
 ## 本リポジトリ実態メモ（2025-09-13 点検）
 
 - ランタイム/ツールチェーン
-  - Node 20.19 系（Docker/GitHub Actions）
+- Node 24.8 系（Docker/GitHub Actions）
   - Vite: `vite@5` + `@vitejs/plugin-react` / React: `16.13.1` / TypeScript: `3.8.3`
   - 状態管理: Redux + Redux-Saga、UI: Bulma
 - ディレクトリ構成（実在確認済み）

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.19-alpine
+FROM node:24.8.0-alpine
 
 ENV HOME /usr/src/app
 RUN mkdir -p $HOME


### PR DESCRIPTION
## Summary
- bump the Docker base image to Node.js v24.8.0 to align with the latest release
- update CI/Deploy workflows and contributor guidance to reference Node.js v24.8.0

## Testing
- yarn lint
- yarn test

------
https://chatgpt.com/codex/tasks/task_e_68ccd3b4168c8329b7b099a109617e65